### PR TITLE
Feature/thumbnail generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 [![PHPCS + Unit Tests](https://github.com/moderntribe/tribe-storage-statically-cdn/actions/workflows/pull-request.yml/badge.svg)](https://github.com/moderntribe/tribe-storage-statically-cdn/actions/workflows/pull-request.yml)
 ![php 7.3+](https://img.shields.io/badge/php-min%207.3-red.svg)
 
-Provides dynamic image sizing via [statically.io](https://statically.io/) and disables WordPress's automatic 
-thumbnail creation.
+Provides dynamic image sizing and optimization via [statically.io](https://statically.io/) and only creates WordPress thumbnails 
+for images that require hard cropping.
 
 ## Installation Composer v1
 
@@ -130,6 +130,26 @@ URL rewriting would look as follows, and proxied to Statically behind the scenes
 - Original: `https://example.com/wp-content/uploads/sites/4/2021/06/image.jpg`
 - Rewritten: `https://example.com/wp-content/uploads/f=auto,w=1024,h=1024/sites/4/2021/06/image.jpg`
 - Proxied URL: `https://cdn.statically.io/img/account.blob.core.windows.net/f=auto,w=1024,h=1024/container/sites/4/2021/06/image.jpg`
+
+## Disable WordPress thumbnail creation
+
+If you're not concerned with exact cropping, you can let statically.io resize your image based with keeping the same
+dimension ratio and disable thumbnail creation to see a large performance boost when uploading new images. 
+
+For this you have two options:
+
+Option 1: Add this define to `wp-config.php`
+```php
+define( 'TRIBE_STORAGE_STATICALLY_CREATE_THUMBNAILS', false );
+```
+
+Option 2: Make the `tribe/storage/plugin/statically/create_thumbnails` filter return false, e.g.
+
+```php
+add_filter( 'tribe/storage/plugin/statically/create_thumbnails', '__return_false' );
+```
+
+> NOTE: Don't forget to clear object caching and regenerate thumbnails each time this option is swaped.
 
 ## Automated Testing
 

--- a/src/Image.php
+++ b/src/Image.php
@@ -115,8 +115,8 @@ class Image {
 			[ $width, $height ] = $size;
 		}
 
-		$url              = wp_get_attachment_url( $id );
-		$intermediate     = image_get_intermediate_size( $id, $size );
+		$url          = wp_get_attachment_url( $id );
+		$intermediate = image_get_intermediate_size( $id, $size );
 
 		if ( $intermediate ) {
 			$url = $intermediate['url'];

--- a/src/Image.php
+++ b/src/Image.php
@@ -21,6 +21,10 @@ class Image {
 	 * @return array
 	 */
 	public function remove_uncropped_image_meta( array $new_sizes ): array {
+		if ( ! apply_filters( 'tribe/storage/plugin/statically/create_thumbnails', true ) ) {
+			return [];
+		}
+
 		foreach ( $new_sizes as $name => $size ) {
 			$crop = $size['crop'] ?? false;
 

--- a/src/Image.php
+++ b/src/Image.php
@@ -28,9 +28,11 @@ class Image {
 		foreach ( $new_sizes as $name => $size ) {
 			$crop = $size['crop'] ?? false;
 
-			if ( ! $crop ) {
-				unset( $new_sizes[ $name ] );
+			if ( true === $crop ) {
+				continue;
 			}
+
+			unset( $new_sizes[ $name ] );
 		}
 
 		return $new_sizes;
@@ -114,7 +116,6 @@ class Image {
 		}
 
 		$url              = wp_get_attachment_url( $id );
-		$img_url_basename = wp_basename( $url );
 		$intermediate     = image_get_intermediate_size( $id, $size );
 
 		if ( $intermediate ) {

--- a/src/Metadata.php
+++ b/src/Metadata.php
@@ -57,9 +57,12 @@ class Metadata {
 
 		foreach ( $intermediate_image_sizes as $s ) {
 
-			if ( isset( $data['sizes'][ $s ] ) ) {
-				$sizes[ $s ] = $data['sizes'][ $s ];
-				continue;
+			// Only use existing sizes if we're generating cropped thumbnails
+			if ( apply_filters( 'tribe/storage/plugin/statically/create_thumbnails', true ) ) {
+				if ( isset( $data['sizes'][ $s ] ) ) {
+					$sizes[ $s ] = $data['sizes'][ $s ];
+					continue;
+				}
 			}
 
 			$sizes[ $s ] = [

--- a/src/Metadata.php
+++ b/src/Metadata.php
@@ -56,6 +56,12 @@ class Metadata {
 		$file                       = basename( $path );
 
 		foreach ( $intermediate_image_sizes as $s ) {
+
+			if ( isset( $data['sizes'][ $s ] ) ) {
+				$sizes[ $s ] = $data['sizes'][ $s ];
+				continue;
+			}
+
 			$sizes[ $s ] = [
 				'width'  => '',
 				'height' => '',

--- a/src/Metadata.php
+++ b/src/Metadata.php
@@ -56,7 +56,6 @@ class Metadata {
 		$file                       = basename( $path );
 
 		foreach ( $intermediate_image_sizes as $s ) {
-
 			// Only use existing sizes if we're generating cropped thumbnails
 			if ( apply_filters( 'tribe/storage/plugin/statically/create_thumbnails', true ) ) {
 				if ( isset( $data['sizes'][ $s ] ) ) {

--- a/src/Providers/Statically_Provider.php
+++ b/src/Providers/Statically_Provider.php
@@ -29,6 +29,25 @@ class Statically_Provider implements Providable {
 	}
 
 	public function register(): void {
+
+		/**
+		 * Determine if we should create thumbnails for WordPress images that require cropping
+		 * as statically.io does not support cropping ability the way WordPress crops images.
+		 *
+		 * If your image sizes do not require cropping or or you don't care about cropping you
+		 * can disable this for an extra performance boost when uploading files as the system
+		 * only needs to create a single image.
+		 *
+		 * @param bool $create Whether we should create cropped thumbnails or not
+		 */
+		add_filter( 'tribe/storage/plugin/statically/create_thumbnails', static function ( bool $create ): bool {
+			if ( ! defined( 'TRIBE_STORAGE_STATICALLY_CREATE_THUMBNAILS' ) ) {
+				return true;
+			}
+
+			return (bool) TRIBE_STORAGE_STATICALLY_CREATE_THUMBNAILS;
+		}, 9, 1 );
+
 		add_filter( 'intermediate_image_sizes_advanced', function ( $new_sizes ) {
 			return $this->image->remove_uncropped_image_meta( $new_sizes );
 		}, 10, 1 );

--- a/src/Providers/Statically_Provider.php
+++ b/src/Providers/Statically_Provider.php
@@ -29,8 +29,9 @@ class Statically_Provider implements Providable {
 	}
 
 	public function register(): void {
-		// Disable automatic creation of thumbnails, we generate them on the fly.
-		add_filter( 'intermediate_image_sizes_advanced', '__return_empty_array' );
+		add_filter( 'intermediate_image_sizes_advanced', function ( $new_sizes ) {
+			return $this->image->remove_uncropped_image_meta( $new_sizes );
+		}, 10, 1 );
 
 		add_filter( 'image_downsize', function ( $downsize, $id, $size ) {
 			return $this->image->downsize( $downsize, (int) $id, $size );

--- a/tests/Unit/ImageTest.php
+++ b/tests/Unit/ImageTest.php
@@ -2,6 +2,7 @@
 
 namespace Tribe\Storage\Plugin\Statically\Tests\Unit;
 
+use Brain\Monkey\Filters;
 use Brain\Monkey\Functions;
 use Tribe\Storage\Plugin\Statically\Image;
 use Tribe\Storage\Plugin\Statically\Tests\TestCase;
@@ -449,6 +450,36 @@ class ImageTest extends TestCase {
 
 		$this->assertCount( 1, $sizes );
 		$this->assertSame( $expected, $sizes );
+	}
+
+	public function test_it_ignores_thumbnail_generation() {
+		$original_sizes = [
+			'thumbnail' => [
+				'width'  => 150,
+				'height' => 150,
+				'crop'   => true,
+			],
+			'medium'    => [
+				'width'  => 300,
+				'height' => 300,
+				'crop'   => false,
+			],
+			'large'     => [
+				'width'  => 600,
+				'height' => 500,
+				'crop'   => false,
+			],
+		];
+
+		// Disable cropped thumbnail creation
+		Filters\expectApplied( 'tribe/storage/plugin/statically/create_thumbnails' )
+			->once()
+			->andReturn( false );
+
+		$image = new Image();
+		$sizes = $image->remove_uncropped_image_meta( $original_sizes );
+
+		$this->assertEmpty( $sizes );
 	}
 
 }


### PR DESCRIPTION
Due to statically.io not supporting a `fit=crop` param at this time, we still need to generate any thumbnail sizes that have a hard crop in order for them to appear as intended.