### PR TITLE
Force every image to be a resized image

### DIFF
--- a/src/Image.php
+++ b/src/Image.php
@@ -186,7 +186,7 @@ class Image {
 			$proxy_url,
 			$width,
 			$height,
-			$downsize,
+			true,
 		], $id, $size );
 
 		wp_cache_set( $cache_key, $data, self::CACHE_GROUP );

--- a/tests/Unit/ImageTest.php
+++ b/tests/Unit/ImageTest.php
@@ -85,7 +85,7 @@ class ImageTest extends TestCase {
 			'https://example.com/wp-content/uploads/f=auto,w=150,h=150/sites/2/2021/06/test-150x150.jpg',
 			150,
 			150,
-			false
+			true
 		], $result );
 	}
 


### PR DESCRIPTION
- force every image to be considered resized in order to properly insert the CDN params